### PR TITLE
prefer Bundler.load_gemspec to eval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,16 @@ on:
       - '*'
 
 jobs:
-  skeleton:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     runs-on: ubuntu-latest
     steps:
-      - run: echo hello
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/lib/hoe/markdown/standalone.rb
+++ b/lib/hoe/markdown/standalone.rb
@@ -6,7 +6,7 @@ class Hoe
       attr_reader :spec
 
       def initialize gem_name
-        @spec = eval(File.read("./#{gem_name}.gemspec"))
+        @spec = Bundler.load_gemspec("#{gem_name}.gemspec")
       end
     end
   end


### PR DESCRIPTION
I've long had this sitting on a local branch, but as a forcing function Ruby 3.3.0 is blowing up on `eval`.