### PR TITLE
fix: don't match issues if they're part of a word

### DIFF
--- a/lib/hoe/markdown/util.rb
+++ b/lib/hoe/markdown/util.rb
@@ -2,6 +2,9 @@ class Hoe
   module Markdown
     module Util
       GITHUB_ISSUE_MENTION_REGEX = %r{
+        # not immediately preceded by a word character
+        (?<!\w)
+
         # issue number, like '#1234'
         \#([[:digit:]]+)
 

--- a/spec/hoe/markdown/util_spec.rb
+++ b/spec/hoe/markdown/util_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe Hoe::Markdown::Util do
         markdown = <<~MD
           leading
           how about issues #1, #23,#456?
+          but not references like Foo#123 or LH#8
           trailing
         MD
 
         expected = <<~MD
           leading
           how about issues [#1](https://example.com/username/projectname/issues/1), [#23](https://example.com/username/projectname/issues/23),[#456](https://example.com/username/projectname/issues/456)?
+          but not references like Foo#123 or LH#8
           trailing
         MD
 


### PR DESCRIPTION
For example, old lighthouse issue references like "LH#123" should not get linkified.