### PR TITLE
Ignore link refs and link ref definitions

### DIFF
--- a/lib/hoe/markdown/util.rb
+++ b/lib/hoe/markdown/util.rb
@@ -57,13 +57,33 @@ class Hoe
         }x
 
         markdown
-          .gsub(GITHUB_ISSUE_MENTION_REGEX, "[#\\1](#{issues_uri}/\\1)")
-          .gsub(issue_uri_regex, "[#\\1](#{issues_uri}/\\1)")
-          .gsub(pull_uri_regex, "[#\\1](#{pull_uri}/\\1)")
+          .gsub(GITHUB_ISSUE_MENTION_REGEX) {
+            __replace_with_link(Regexp.last_match, "[#%<id>s](#{issues_uri}/%<id>s)")
+          }
+          .gsub(issue_uri_regex) {
+            __replace_with_link(Regexp.last_match, "[#%<id>s](#{issues_uri}/%<id>s)")
+          }
+          .gsub(pull_uri_regex) {
+            __replace_with_link(Regexp.last_match, "[#%<id>s](#{pull_uri}/%<id>s)")
+          }
       end
 
       def self.linkify_github_usernames(markdown)
-        markdown.gsub(GITHUB_USER_REGEX, "[@\\1](https://github.com/\\1)")
+        markdown.gsub(GITHUB_USER_REGEX) {
+          __replace_with_link(Regexp.last_match, "[@%<id>s](https://github.com/%<id>s)")
+        }
+      end
+
+      def self.__replace_with_link(match, link)
+        skip =
+          (match.pre_match.end_with?("\n[") && match.post_match =~ /\A\]:\s+.+\n/) ||
+          (match.pre_match =~ /\]\[[^\]]*\z/ && match.post_match =~ /\A[^\]]*\]/)
+
+        if skip
+          match[0]
+        else
+          link % {id: match[1]}
+        end
       end
     end
   end

--- a/spec/hoe/markdown/util_spec.rb
+++ b/spec/hoe/markdown/util_spec.rb
@@ -8,14 +8,20 @@ RSpec.describe Hoe::Markdown::Util do
           leading
           how about issues #1, #23,#456?
           but not references like Foo#123 or LH#8
-          trailing
+          trailing [#45][test-#45-test] [#46][#46]
+
+          [#45]: https://github.com/username/projectname/issues/45
+          [#46]: https://github.com/username/projectname/pull/46
         MD
 
         expected = <<~MD
           leading
           how about issues [#1](https://example.com/username/projectname/issues/1), [#23](https://example.com/username/projectname/issues/23),[#456](https://example.com/username/projectname/issues/456)?
           but not references like Foo#123 or LH#8
-          trailing
+          trailing [#45][test-#45-test] [#46][#46]
+
+          [#45]: https://github.com/username/projectname/issues/45
+          [#46]: https://github.com/username/projectname/pull/46
         MD
 
         actual = Hoe::Markdown::Util.linkify_github_issues(markdown, issues_uri)
@@ -106,6 +112,8 @@ RSpec.describe Hoe::Markdown::Util do
         foo @flavorjones and @asdfqwer bar
         foo @y-yagi bar
         trailing
+
+        [@y-yagi]: https://github.com/y-yagi
       MD
 
       expected = <<~MD
@@ -113,6 +121,8 @@ RSpec.describe Hoe::Markdown::Util do
         foo [@flavorjones](https://github.com/flavorjones) and [@asdfqwer](https://github.com/asdfqwer) bar
         foo [@y-yagi](https://github.com/y-yagi) bar
         trailing
+
+        [@y-yagi]: https://github.com/y-yagi
       MD
 
       expect(Hoe::Markdown::Util.linkify_github_usernames(markdown)).to eq(expected)

--- a/spec/hoe/markdown/util_spec.rb
+++ b/spec/hoe/markdown/util_spec.rb
@@ -8,20 +8,24 @@ RSpec.describe Hoe::Markdown::Util do
           leading
           how about issues #1, #23,#456?
           but not references like Foo#123 or LH#8
-          trailing [#45][test-#45-test] [#46][#46]
+          should not change [#45][test-#45-test] [#46][#46]
 
           [#45]: https://github.com/username/projectname/issues/45
           [#46]: https://github.com/username/projectname/pull/46
+
+          trailing
         MD
 
         expected = <<~MD
           leading
           how about issues [#1](https://example.com/username/projectname/issues/1), [#23](https://example.com/username/projectname/issues/23),[#456](https://example.com/username/projectname/issues/456)?
           but not references like Foo#123 or LH#8
-          trailing [#45][test-#45-test] [#46][#46]
+          should not change [#45][test-#45-test] [#46][#46]
 
           [#45]: https://github.com/username/projectname/issues/45
           [#46]: https://github.com/username/projectname/pull/46
+
+          trailing
         MD
 
         actual = Hoe::Markdown::Util.linkify_github_issues(markdown, issues_uri)
@@ -111,18 +115,20 @@ RSpec.describe Hoe::Markdown::Util do
         leading
         foo @flavorjones and @asdfqwer bar
         foo @y-yagi bar
-        trailing
 
         [@y-yagi]: https://github.com/y-yagi
+
+        trailing
       MD
 
       expected = <<~MD
         leading
         foo [@flavorjones](https://github.com/flavorjones) and [@asdfqwer](https://github.com/asdfqwer) bar
         foo [@y-yagi](https://github.com/y-yagi) bar
-        trailing
 
         [@y-yagi]: https://github.com/y-yagi
+
+        trailing
       MD
 
       expect(Hoe::Markdown::Util.linkify_github_usernames(markdown)).to eq(expected)


### PR DESCRIPTION
Links that look like `[#45][#45]` will be converted incorrectly because it does not match the existing boundary. Specifically, the *second* instance of `[#45]` will be converted into an inline link, even though this is a link reference. Similarly, the issue/pull linking would overconvert the definition of link references (`[foo]: uri`).

This change specifically looks for these two cases (link ref and link ref definition) in the pre/post match values from the `#gsub` match and if either of these cases is met, the original matching text is returned unmodified.

It is *possible* that this could be partially fixed in the main regex definitions, but those are already complex and while I understand regex well, I could not figure out the right way to manage this because of the contextual complexity involved.

This would be much better managed as transforms over a parsed Markdown AST where the replacements could be applied to pure text nodes while already ignoring things that are identified as link definitions (maybe [comrak](https://crates.io/crates/comrak)).

Resolves: #3